### PR TITLE
Apparently this is better for CLS

### DIFF
--- a/themes/pdp80-theme/assets/css/pdp.css
+++ b/themes/pdp80-theme/assets/css/pdp.css
@@ -180,6 +180,7 @@ th {
 
 img {
   width: calc(100% + 40px);
+  height: auto;
   margin-left: calc(-20px);
   margin-right: calc(-20px);
 }

--- a/themes/pdp80-theme/layouts/shortcodes/figure.html
+++ b/themes/pdp80-theme/layouts/shortcodes/figure.html
@@ -3,7 +3,7 @@
   {{ $image := resources.Get $path }}
   {{ $image := $image.Fit "768x1024 q75" }}
   <figure class="{{ with .Get "position"}}{{ . }}{{ else -}} left {{- end }}" >
-    <img src="{{ $image.RelPermalink }}" {{ with .Get "alt" }} alt="{{ . | plainify }}" {{ end }} {{ with .Get "style" }} style="{{ . | safeCSS }}" {{ end }} class="aspect-ratio: {{ $image.Width }} / {{ $image.Height }}" />
+    <img src="{{ $image.RelPermalink }}" {{ with .Get "alt" }} alt="{{ . | plainify }}" {{ end }} {{ with .Get "style" }} style="{{ . | safeCSS }}" {{ end }} width="{{ $image.Width }}" height="{{ $image.Height }}" />
     {{ if .Get "caption" }}
       <figcaption class="{{ with .Get "captionPosition"}}{{ . }}{{ else -}} center {{- end }}" {{ with .Get "captionStyle" }} style="{{ . | safeCSS }}" {{ end }}>{{ .Get "caption" | safeHTML }}</figcaption>
     {{ end }}


### PR DESCRIPTION
Explicitly define width and height on the <img> tag. Then the CSS for "img" you say "height: auto"